### PR TITLE
Remove third party module

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -458,9 +458,9 @@ import io
 import json
 import os
 import re
-import requests
 import sys
-from requests.auth import HTTPBasicAuth
+import base64
+import urllib2
 
 # 𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗
 # ⁰¹²³⁴⁵⁶⁷⁸⁹
@@ -481,9 +481,9 @@ cache = os.getenv('cache')
 #
 if os.path.isfile(cache) and os.path.getsize(cache) == 0:
     url = 'https://api.github.com/user/repos?page=1&amp;per_page=1000'
-    auth = HTTPBasicAuth(user, token)
-    response = requests.get(url, auth=auth)
-    data = json.loads(response.text)
+    auth = {'Authorization': 'Basic ' + base64.b64encode(user + ':' + token)}
+    response = urllib2.urlopen(urllib2.Request(url, headers=auth)).read()
+    data = json.loads(response)
     with io.open(cache, 'w', encoding='utf8') as cacheFile:
         dumpedData = json.dumps(data, ensure_ascii=False)
         cacheFile.write(unicode(dumpedData))


### PR DESCRIPTION
I noticed that it is required the `requests` module for this workflow to work, but it currently requires that the user has installed it on its own (the `requests` module is not builtin on a mac). Because of this reason the workflow was not working for me.

I can think of 2 solutions:
1. Follow [Alfred's documentation](https://alfredworkflow.readthedocs.io/en/latest/user-manual/third-party.html)
2. As the usage is fairly small, replace the `requests` usage with what Python 2 provides.

To keep things simple I chose the second option :)